### PR TITLE
feat: typesafe regex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,43 @@ When('I am {word} the count', (state: MyState, [operation]) => {
 });
 ```
 
+#### Using with RegExp
+
+```ts
+import { Before, Given, When } from '@aboviq/bun-test-cucumber';
+
+interface MyState {
+  count: number;
+}
+
+Before<MyState>((state) => ({ ...state, count: 0 }));
+
+// untyped regexp
+Given(/the count is (\\d+|zero)/, (state: MyState, [count]) => {
+  // inferred as string | undefined
+  if (!count || count === 'zero') {
+    return { ...state, count: 0 };
+  }
+
+  return { ...state, count: Number(count) };
+});
+
+// simple typed regexp (note that it's a regex-like string)
+When('/I am (increasing|decreasing|doubling) the count/', (state: MyState, [operation]) => {
+  typeof operation; // inferred as 'increasing' | 'decreasing' | 'doubling'
+  switch (operation) {
+    case 'increasing':
+      return { ...state, count: state.count + 1 };
+    case 'decreasing':
+      return { ...state, count: state.count - 1 };
+    case 'doubling':
+      return { ...state, count: state.count * 2 };
+    default:
+      throw new Error(`Unknown operation: ${operation}`);
+  }
+});
+```
+
 ## License
 
 MIT © [Aboviq AB](https://aboviq.com)

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@cucumber/gherkin": "^35.1.0",
         "@cucumber/messages": "^30.0.0",
         "@cucumber/tag-expressions": "^7.0.0",
+        "arkregex": "^0.0.3",
       },
       "devDependencies": {
         "@prettier/plugin-oxc": "^0.0.4",
@@ -21,6 +22,8 @@
     },
   },
   "packages": {
+    "@ark/util": ["@ark/util@0.55.0", "", {}, "sha512-aWFNK7aqSvqFtVsl1xmbTjGbg91uqtJV7Za76YGNEwIO4qLjMfyY8flmmbhooYMuqPCO2jyxu8hve943D+w3bA=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
@@ -138,6 +141,8 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "arkregex": ["arkregex@0.0.3", "", { "dependencies": { "@ark/util": "0.55.0" } }, "sha512-bU21QJOJEFJK+BPNgv+5bVXkvRxyAvgnon75D92newgHxkBJTgiFwQxusyViYyJkETsddPlHyspshDQcCzmkNg=="],
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 

--- a/features/regexp-steps.feature
+++ b/features/regexp-steps.feature
@@ -1,0 +1,24 @@
+Feature: The library allows RegExp in Steps
+
+  Scenario: Process raw regexp
+    Given the step is defined with a regexp
+    Then the step extracts groups as arguments
+      | the step is defined with a |
+      | regexp |
+
+
+  Scenario Outline: Process typed regexp
+    Given the step is defined with a string
+    When the string is clamped with <start> and <end>
+      | <start> |
+      | <end>   |
+    Then the step extracts groups as arguments
+      | the step is defined with a |
+      | string |
+    And the arguments have types from capture groups
+    And the types notify about optional groups
+
+    Examples:
+      | start | end |
+      | ^     | $   |
+      | /     | /   |

--- a/features/simple-scenario.feature
+++ b/features/simple-scenario.feature
@@ -3,9 +3,7 @@ Feature: My First Feature
   Scenario: Handle integers
     When I set counter to 10
     Then I should see the counter is a number
-    Then I should see the counter as a number
 
   Scenario: Handle big integers
     When I set counter to big 20
     Then I should see the counter is a bigint
-    Then I should see the counter as a bigint

--- a/features/simple-scenario.feature
+++ b/features/simple-scenario.feature
@@ -3,7 +3,9 @@ Feature: My First Feature
   Scenario: Handle integers
     When I set counter to 10
     Then I should see the counter is a number
+    Then I should see the counter as a number
 
   Scenario: Handle big integers
     When I set counter to big 20
     Then I should see the counter is a bigint
+    Then I should see the counter as a bigint

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@cucumber/cucumber-expressions": "^18.0.1",
     "@cucumber/gherkin": "^35.1.0",
     "@cucumber/messages": "^30.0.0",
-    "@cucumber/tag-expressions": "^7.0.0"
+    "@cucumber/tag-expressions": "^7.0.0",
+    "arkregex": "^0.0.3"
   },
   "devDependencies": {
     "@prettier/plugin-oxc": "^0.0.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,14 +148,14 @@ export interface AddHookFunction<S> {
 }
 
 export interface AddStepFunction<S> {
-  <Pattern extends string, State = S>(
+  <Pattern extends string | RegExp, State = S>(
     pattern: Pattern,
     fn: (state: State, args: ExtractTypes<Pattern>, data?: PickleStepArgument) => State | Promise<State>,
   ): void;
 }
 
 export interface AddStepFunctionWithState<State> {
-  <Pattern extends string>(
+  <Pattern extends string | RegExp>(
     pattern: Pattern,
     fn: (state: State, args: ExtractTypes<Pattern>, data?: PickleStepArgument) => State | Promise<State>,
   ): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,10 @@ export interface AddStepFunction<S> {
     pattern: Pattern,
     fn: (state: State, args: ExtractTypes<Pattern>, data?: PickleStepArgument) => State | Promise<State>,
   ): void;
+  <State = S>(
+    pattern: string | RegExp,
+    fn: (state: State, args: Array<string | undefined>, data?: PickleStepArgument) => State | Promise<State>,
+  ): void;
 }
 
 export interface AddStepFunctionWithState<State> {
@@ -168,6 +172,10 @@ export interface AddStepFunctionWithState<State> {
   <Pattern extends string>(
     pattern: Pattern,
     fn: (state: State, args: ExtractTypes<Pattern>, data?: PickleStepArgument) => State | Promise<State>,
+  ): void;
+  (
+    pattern: string | RegExp,
+    fn: (state: State, args: Array<string | undefined>, data?: PickleStepArgument) => State | Promise<State>,
   ): void;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,14 +148,24 @@ export interface AddHookFunction<S> {
 }
 
 export interface AddStepFunction<S> {
-  <Pattern extends string | RegExp, State = S>(
+  // Early termination for RegExp types
+  <State = S>(
+    pattern: RegExp,
+    fn: (state: State, args: Array<string | undefined>, data?: PickleStepArgument) => State | Promise<State>,
+  ): void;
+  <Pattern extends string, State = S>(
     pattern: Pattern,
     fn: (state: State, args: ExtractTypes<Pattern>, data?: PickleStepArgument) => State | Promise<State>,
   ): void;
 }
 
 export interface AddStepFunctionWithState<State> {
-  <Pattern extends string | RegExp>(
+  // Early termination for RegExp types
+  (
+    pattern: RegExp,
+    fn: (state: State, args: Array<string | undefined>, data?: PickleStepArgument) => State | Promise<State>,
+  ): void;
+  <Pattern extends string>(
     pattern: Pattern,
     fn: (state: State, args: ExtractTypes<Pattern>, data?: PickleStepArgument) => State | Promise<State>,
   ): void;
@@ -222,20 +232,16 @@ export interface WithState<S> {
  * @returns Hook and step definitions with state type inference
  */
 export const withState = <State>(): WithState<State> => {
-  const addStepWithState: AddStepFunctionWithState<State> = (pattern, fn) => {
-    addStep(pattern, fn);
-  };
-
   return {
-    BeforeAll: BeforeAll<State>,
-    Before: Before<State>,
-    BeforeStep: BeforeStep<State>,
-    AfterStep: AfterStep<State>,
-    After: After<State>,
-    AfterAll: AfterAll<State>,
-    Given: addStepWithState,
-    When: addStepWithState,
-    Then: addStepWithState,
+    BeforeAll,
+    Before,
+    BeforeStep,
+    AfterStep,
+    After,
+    AfterAll,
+    Given,
+    When,
+    Then,
   };
 };
 
@@ -263,16 +269,9 @@ export const AfterAll: AddHookFunction<unknown> = (...args: unknown[]) => {
   addHook('afterAll', ...args);
 };
 
-export const Given: AddStepFunction<unknown> = (pattern, fn) => {
-  addStep(pattern, fn);
-};
-
-export const When: AddStepFunction<unknown> = (pattern, fn) => {
-  addStep(pattern, fn);
-};
-export const Then: AddStepFunction<unknown> = (pattern, fn) => {
-  addStep(pattern, fn);
-};
+export const Given: AddStepFunction<unknown> = addStep;
+export const When: AddStepFunction<unknown> = addStep;
+export const Then: AddStepFunction<unknown> = addStep;
 
 /**
  * Extracts and transforms the data table from a PickleStep argument

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,7 @@ const steps: Step[] = [];
 const hooks = new Map<HookType, Hook<unknown>[]>();
 
 export const addStep = (expression: string | RegExp, fn: Function): void => {
-  const cucumberExpression = typeof expression === 'string' && /^\/.*\/$/.test(expression)
+  const cucumberExpression = typeof expression === 'string' && /^\/.*\/$|^\^.*\$$/.test(expression)
     ? expressionFactory.createExpression(new RegExp(expression.slice(1, -1)))
     : expressionFactory.createExpression(expression);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,8 +10,10 @@ const steps: Step[] = [];
 
 const hooks = new Map<HookType, Hook<unknown>[]>();
 
-export const addStep = (expression: string, fn: Function): void => {
-  const cucumberExpression = expressionFactory.createExpression(expression);
+export const addStep = (expression: string | RegExp, fn: Function): void => {
+  const cucumberExpression = typeof expression === 'string' && /^\/.*\/$/.test(expression)
+    ? expressionFactory.createExpression(new RegExp(expression.slice(1, -1)))
+    : expressionFactory.createExpression(expression);
 
   if (!fn.name) {
     Object.defineProperty(fn, 'name', { value: expression });

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,41 @@ type ExtractGherkinDataTypes<T extends string, S extends GherkinDataType[]> = T 
   ? ExtractGherkinDataTypes<W, ExtractGherkinDataType<U, S>>
   : ExtractGherkinDataType<T, S>;
 
-export type ExtractTypes<T extends string> = GherkinDataTypesToTypes<ExtractGherkinDataTypes<T, []>>;
+export type ExtractTypes<T extends string | RegExp> =
+  T extends `/${infer Regex}/`
+  ? ExtractRegexGroups<Regex, []>
+  : T extends string
+    ? GherkinDataTypesToTypes<ExtractGherkinDataTypes<T, []>>
+    : (string | undefined)[];
+
+type ExtractRegexGroups<T extends string, Groups extends unknown[]> =
+  T extends `${string}(${infer Group})${infer Q extends MaybeOptionalLiteral}${string}`
+    ? Group extends `?:${infer SubGroup}` | `?!${infer SubGroup}`
+      ? ExtractRegexGroups<SubGroup, Groups>
+      : Group extends `?<${string}>${infer SubGroup}`
+        ? ExtractRegexGroups<SubGroup, [...Groups, ExtractSimpleGroupTypes<SubGroup> | MaybeOptional<Q>]>
+        : ExtractRegexGroups<Group, [...Groups, ExtractSimpleGroupTypes<Group> | MaybeOptional<Q>]>
+    : Groups;
+
+type ExtractSimpleGroupTypes<G extends string, Types = never> =
+  G extends `${infer Left}|${infer Right}`
+    ? Types | ExtractSimpleGroupTypes<Left> | ExtractSimpleGroupTypes<Right>
+    : ExtractRegexToken<G>;
+
+type ExtractRegexToken<G extends string> =
+  G extends `\\${infer Type}${infer Q extends MaybeOptionalLiteral}`
+    ? ExtractRegexTokenType<Q, Type>
+  : G extends `[${infer Type}]${infer Q extends MaybeOptionalLiteral}`
+    ? ExtractRegexTokenType<Q, Type>
+    : G;
+
+type ExtractRegexTokenType<Optional extends string, _Type extends string> =
+  MaybeOptional<Optional> | string;
+
+type MaybeOptional<Optional extends string> = (Optional extends OptionalLiteral ? undefined : never);
+
+type MaybeOptionalLiteral = '' | '+' | OptionalLiteral;
+type OptionalLiteral = '*' | '+?' | '*?' | '?';
 
 export type HookType = 'beforeAll' | 'before' | 'beforeStep' | 'afterStep' | 'after' | 'afterAll';
 
@@ -59,7 +93,7 @@ export type Hook<State> = {
 };
 
 export type Step = {
-  expression: string;
+  expression: string | RegExp;
   cucumberExpression: CucumberExpression;
   fn: Function;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,11 @@ export type ExtractTypes<T extends string> =
     : GherkinDataTypesToTypes<ExtractGherkinDataTypes<T>>;
 
 type RegexString<T extends string> = `/${T}/` | `^${T}$`;
-type ExtractRegexGroups<T extends string> = regex.parse<`^${T}$`> extends { inferCaptures: infer C } ? C : (string | undefined)[];
+type ExtractRegexGroups<T extends string> = regex.parse<`^${T}$`> extends { inferCaptures: infer C }
+  // Cucumber treats optional regexp groups as null values instead of undefined,
+  // probably due to its java roots?
+  ? { [k in keyof C]: undefined extends C[k] ? null : C[k] }
+  : (string | undefined)[];
 
 export type HookType = 'beforeAll' | 'before' | 'beforeStep' | 'afterStep' | 'after' | 'afterAll';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { ExpressionFactory } from '@cucumber/cucumber-expressions';
 import parseTags from '@cucumber/tag-expressions';
+import type { regex } from 'arkregex';
 
 export type TagExpression = ReturnType<typeof parseTags>;
 
@@ -42,45 +43,17 @@ type ExtractGherkinDataType<
   S extends GherkinDataType[],
 > = T extends `${string}{${infer U extends GherkinDataType}` ? [...S, U] : S;
 
-type ExtractGherkinDataTypes<T extends string, S extends GherkinDataType[]> = T extends `${infer U}}${infer W}`
+type ExtractGherkinDataTypes<T extends string, S extends GherkinDataType[] = []> = T extends `${infer U}}${infer W}`
   ? ExtractGherkinDataTypes<W, ExtractGherkinDataType<U, S>>
   : ExtractGherkinDataType<T, S>;
 
-export type ExtractTypes<T extends string | RegExp> =
-  T extends `/${infer Regex}/`
-  ? ExtractRegexGroups<Regex, []>
-  : T extends string
-    ? GherkinDataTypesToTypes<ExtractGherkinDataTypes<T, []>>
-    : (string | undefined)[];
+export type ExtractTypes<T extends string> =
+  T extends RegexString<infer Regex>
+    ? ExtractRegexGroups<Regex>
+    : GherkinDataTypesToTypes<ExtractGherkinDataTypes<T>>;
 
-type ExtractRegexGroups<T extends string, Groups extends unknown[]> =
-  T extends `${string}(${infer Group})${infer Q extends MaybeOptionalLiteral}${string}`
-    ? Group extends `?:${infer SubGroup}` | `?!${infer SubGroup}`
-      ? ExtractRegexGroups<SubGroup, Groups>
-      : Group extends `?<${string}>${infer SubGroup}`
-        ? ExtractRegexGroups<SubGroup, [...Groups, ExtractSimpleGroupTypes<SubGroup> | MaybeOptional<Q>]>
-        : ExtractRegexGroups<Group, [...Groups, ExtractSimpleGroupTypes<Group> | MaybeOptional<Q>]>
-    : Groups;
-
-type ExtractSimpleGroupTypes<G extends string, Types = never> =
-  G extends `${infer Left}|${infer Right}`
-    ? Types | ExtractSimpleGroupTypes<Left> | ExtractSimpleGroupTypes<Right>
-    : ExtractRegexToken<G>;
-
-type ExtractRegexToken<G extends string> =
-  G extends `\\${infer Type}${infer Q extends MaybeOptionalLiteral}`
-    ? ExtractRegexTokenType<Q, Type>
-  : G extends `[${infer Type}]${infer Q extends MaybeOptionalLiteral}`
-    ? ExtractRegexTokenType<Q, Type>
-    : G;
-
-type ExtractRegexTokenType<Optional extends string, _Type extends string> =
-  MaybeOptional<Optional> | string;
-
-type MaybeOptional<Optional extends string> = (Optional extends OptionalLiteral ? undefined : never);
-
-type MaybeOptionalLiteral = '' | '+' | OptionalLiteral;
-type OptionalLiteral = '*' | '+?' | '*?' | '?';
+type RegexString<T extends string> = `/${T}/` | `^${T}$`;
+type ExtractRegexGroups<T extends string> = regex.parse<`^${T}$`> extends { inferCaptures: infer C } ? C : (string | undefined)[];
 
 export type HookType = 'beforeAll' | 'before' | 'beforeStep' | 'afterStep' | 'after' | 'afterAll';
 

--- a/tests/regexp.steps.ts
+++ b/tests/regexp.steps.ts
@@ -1,0 +1,73 @@
+import { expect } from 'bun:test';
+
+import type { PickleStepArgument } from '@cucumber/messages';
+
+import { withState } from '../src';
+
+interface State {
+  args: unknown[];
+}
+
+const { Given, When, Then } = withState<State>();
+
+Given(/(the step is defined with a) (string|regexp)/, (_, args) => {
+  return { args };
+});
+
+
+When('/the string is clamped with (\\/) and (\\/)/', (state, args, data) => {
+  expectArgsToMatchData(args, data);
+  return state;
+});
+
+When('^the string is clamped with (\\^) and (\\$)$', (state, args, data) => {
+  expectArgsToMatchData(args, data);
+  return state;
+});
+
+function expectArgsToMatchData(args: (string | undefined)[], data?: PickleStepArgument) {
+  expect(args).toBeArrayOfSize(data?.dataTable?.rows.length!);
+
+  data?.dataTable?.rows.forEach((row, i) =>
+    expect(args[i]).toBe(row.cells[0]?.value)
+  );
+}
+
+
+Then(/the step extracts groups as arguments/, (state, _, data) => {
+  expect(data?.dataTable).not.toBeUndefined();
+
+  expect(state.args)
+    .toEqual(data!.dataTable!.rows.map(r => r.cells[0]?.value));
+
+  return state;
+});
+
+const _arguments = 'arguments';
+const types = 'types';
+const groups = 'groups';
+Then(`/the (${_arguments}) have (${types}) from capture (${groups})/`, (state, args) => {
+  expect(args[0]).toBe(_arguments);
+  expect(args[1]).toBe(types);
+  expect(args[2]).toBe(groups);
+
+  // @ts-expect-error there are only three capture groups
+  expect(args[3]).toBeUndefined();
+
+  return state;
+});
+
+Then(`^the (${types}) notify about optional (capture )?(${groups})$`, (state, args) => {
+  expect(args[0]).toBe(types);
+  expect(args[1]).toBe(null);
+
+  //@ts-expect-error TypeScript should expect args[1] to be string | undefined
+  const _: string = args[1];
+
+  expect(args[2]).toBe(groups);
+
+  // @ts-expect-error there are only three capture groups
+  expect(args[3]).toBeUndefined();
+
+  return state;
+});

--- a/tests/some.steps.ts
+++ b/tests/some.steps.ts
@@ -29,8 +29,8 @@ When('I increase the counter by {int}', async (state, [value]) => {
   return { ...state, counter: typeof state.counter === 'number' ? state.counter + value : state.counter };
 });
 
-When(/I set counter to (\d+)/, async (state, [value]) => {
-  return { ...state, counter: Number(value) };
+When('I set counter to {int}', async (state, [value]) => {
+  return { ...state, counter: value };
 });
 
 When('I set counter to big {biginteger}', async (state, [value]) => {
@@ -39,32 +39,6 @@ When('I set counter to big {biginteger}', async (state, [value]) => {
 
 Then('It should match snapshot', async (state) => {
   expect(state.counter).toMatchSnapshot();
-
-  return state;
-});
-
-Then('^I should see the counter as a (number|bigint)$', async (state, [type]) => {
-  switch (type) {
-    case 'number':
-    case 'bigint':
-      expect(state.counter).toBeTypeOf(type);
-      break;
-    default:
-      throw new Error(`Unknown type: ${type}`);
-  }
-
-  return state;
-});
-
-Then('/I should see the counter as a (number|bigint)/', async (state, [type]) => {
-  switch (type) {
-    case 'number':
-    case 'bigint':
-      expect(state.counter).toBeTypeOf(type);
-      break;
-    default:
-      throw new Error(`Unknown type: ${type}`);
-  }
 
   return state;
 });

--- a/tests/some.steps.ts
+++ b/tests/some.steps.ts
@@ -1,5 +1,6 @@
 import { expect } from 'bun:test';
-import { withState, getDataTable } from '../src';
+
+import { getDataTable, withState } from '../src';
 
 interface State {
   counter: number | bigint;
@@ -28,8 +29,8 @@ When('I increase the counter by {int}', async (state, [value]) => {
   return { ...state, counter: typeof state.counter === 'number' ? state.counter + value : state.counter };
 });
 
-When('I set counter to {int}', async (state, [value]) => {
-  return { ...state, counter: value };
+When(/I set counter to (\d+)/, async (state, [value]) => {
+  return { ...state, counter: Number(value) };
 });
 
 When('I set counter to big {biginteger}', async (state, [value]) => {
@@ -38,6 +39,32 @@ When('I set counter to big {biginteger}', async (state, [value]) => {
 
 Then('It should match snapshot', async (state) => {
   expect(state.counter).toMatchSnapshot();
+
+  return state;
+});
+
+Then('^I should see the counter as a (number|bigint)$', async (state, [type]) => {
+  switch (type) {
+    case 'number':
+    case 'bigint':
+      expect(state.counter).toBeTypeOf(type);
+      break;
+    default:
+      throw new Error(`Unknown type: ${type}`);
+  }
+
+  return state;
+});
+
+Then('/I should see the counter as a (number|bigint)/', async (state, [type]) => {
+  switch (type) {
+    case 'number':
+    case 'bigint':
+      expect(state.counter).toBeTypeOf(type);
+      break;
+    default:
+      throw new Error(`Unknown type: ${type}`);
+  }
 
   return state;
 });


### PR DESCRIPTION
Cucumber supports regex in step definitions, so let's support it here too.

This PR also introduces typed regexes via [strings formatted like regexes](https://github.com/cucumber/cucumber-expressions#:~:text=To%20use%20Regular%20Expressions%2C%20add%20anchors%20(starting%20with%20%5E%20and%20ending%20with%20%24)%20or%20forward%20slashes%20(/)) to simplify processing args for most common regex use-cases:
```ts
// simple typed regexp (note that it's a regex-like string)
When('/I am (increasing|decreasing|doubling) the count/', (state: MyState, [operation]) => {
  typeof operation; // inferred as 'increasing' | 'decreasing' | 'doubling'
  switch (operation) {
    case 'increasing':
      return { ...state, count: state.count + 1 };
    case 'decreasing':
      return { ...state, count: state.count - 1 };
    case 'doubling':
      return { ...state, count: state.count * 2 };
    default:
      throw new Error(`Unknown operation: ${operation}`);
  }
});
```

This comes with a _type-only_ dependency on [`arkregex`](https://arktype.io/docs/blog/arkregex) - a relatively young library - for the regex type inference.